### PR TITLE
feat(chainID): Update to v16

### DIFF
--- a/x/evm/keeper/keeper.go
+++ b/x/evm/keeper/keeper.go
@@ -119,10 +119,6 @@ func (k *Keeper) WithChainID(ctx sdk.Context) {
 		panic("chain id already set")
 	}
 
-	if !(chainID.Cmp(big.NewInt(9001)) == 0 || chainID.Cmp(big.NewInt(9000)) == 0) {
-		panic("EVM only supports Evmos chain identifiers (9000 or 9001)")
-	}
-
 	k.eip155ChainID = chainID
 }
 

--- a/x/evm/types/access_list_tx.go
+++ b/x/evm/types/access_list_tx.go
@@ -224,13 +224,6 @@ func (tx AccessListTx) Validate() error {
 		)
 	}
 
-	if !(chainID.Cmp(big.NewInt(9001)) == 0 || chainID.Cmp(big.NewInt(9000)) == 0) {
-		return errorsmod.Wrapf(
-			errortypes.ErrInvalidChainID,
-			"chain ID must be 9000 or 9001 on Evmos, got %s", chainID,
-		)
-	}
-
 	return nil
 }
 

--- a/x/evm/types/dynamic_fee_tx.go
+++ b/x/evm/types/dynamic_fee_tx.go
@@ -256,13 +256,6 @@ func (tx DynamicFeeTx) Validate() error {
 		)
 	}
 
-	if !(chainID.Cmp(big.NewInt(9001)) == 0 || chainID.Cmp(big.NewInt(9000)) == 0) {
-		return errorsmod.Wrapf(
-			errortypes.ErrInvalidChainID,
-			"chain ID must be 9000 or 9001 on Evmos, got %s", chainID,
-		)
-	}
-
 	return nil
 }
 

--- a/x/evm/types/legacy_tx.go
+++ b/x/evm/types/legacy_tx.go
@@ -201,13 +201,6 @@ func (tx LegacyTx) Validate() error {
 		)
 	}
 
-	if !(chainID.Cmp(big.NewInt(9001)) == 0 || chainID.Cmp(big.NewInt(9000)) == 0) {
-		return errorsmod.Wrapf(
-			errortypes.ErrInvalidChainID,
-			"chain ID must be 9000 or 9001 on Evmos, got %s", chainID,
-		)
-	}
-
 	return nil
 }
 

--- a/x/evm/types/msg_test.go
+++ b/x/evm/types/msg_test.go
@@ -430,19 +430,6 @@ func (suite *MsgsTestSuite) TestMsgEthereumTx_ValidateBasic() {
 			expectPass: false,
 			errMsg:     "failed to unpack tx data",
 		},
-		{
-			msg:        "invalid chain ID (neither 9000 nor 9001)",
-			to:         suite.to.Hex(),
-			amount:     hundredInt,
-			gasLimit:   1000,
-			gasPrice:   zeroInt,
-			gasFeeCap:  nil,
-			gasTipCap:  nil,
-			accessList: &ethtypes.AccessList{},
-			chainID:    hundredInt,
-			expectPass: false,
-			errMsg:     "chain ID must be 9000 or 9001 on Evmos",
-		},
 	}
 
 	for _, tc := range testCases {


### PR DESCRIPTION
## Description

This PR cherry-picks the existing commit to the v16.0.x branch. Then, we can update the dependency to v16 to fix the EVM error. The commits regarding claims module removal aren't cherry-picked here, because the v16 has removed the claims and recovery modules.