### PR TITLE
fix(patch): move the patch to fix the vulnerability CVE-2024-32644

### DIFF
--- a/x/evm/statedb/state_object.go
+++ b/x/evm/statedb/state_object.go
@@ -60,6 +60,10 @@ type stateObject struct {
 	originStorage Storage
 	dirtyStorage  Storage
 
+	// transientStorage is an in memory storage of the latest committed entries in the current transaction execution.
+	// It is only used when multiple commits are made within the same transaction execution.
+	transientStorage Storage
+
 	address common.Address
 
 	// flags
@@ -76,11 +80,12 @@ func newObject(db *StateDB, address common.Address, account Account) *stateObjec
 		account.CodeHash = emptyCodeHash
 	}
 	return &stateObject{
-		db:            db,
-		address:       address,
-		account:       account,
-		originStorage: make(Storage),
-		dirtyStorage:  make(Storage),
+		db:               db,
+		address:          address,
+		account:          account,
+		originStorage:    make(Storage),
+		dirtyStorage:     make(Storage),
+		transientStorage: make(Storage),
 	}
 }
 


### PR DESCRIPTION
## Description

This PR moves the patch to V16 to fix the vulnerability CVE-2024-32644 regarding transaction execution not accounting for all state transitions after interaction with precompiles.
Please refer to the following link for more details:
[CVE-2024-32644](https://github.com/advisories/GHSA-3fp5-2xwh-fxm6)
