### PR TITLE
fix(evm): handle precompile error gracefully

### DIFF
--- a/precompiles/bank/bank.go
+++ b/precompiles/bank/bank.go
@@ -99,7 +99,7 @@ func (p Precompile) RequiredGas(input []byte) uint64 {
 
 // Run executes the precompiled contract bank query methods defined in the ABI.
 func (p Precompile) Run(evm *vm.EVM, contract *vm.Contract, readOnly bool) (bz []byte, err error) {
-	ctx, stateDB, snapshot, method, initialGas, args, err := p.RunSetup(evm, contract, readOnly, p.IsTransaction)
+	ctx, _, method, initialGas, args, err := p.RunSetup(evm, contract, readOnly, p.IsTransaction)
 	if err != nil {
 		return nil, err
 	}
@@ -129,14 +129,6 @@ func (p Precompile) Run(evm *vm.EVM, contract *vm.Contract, readOnly bool) (bz [
 	if !contract.UseGas(cost) {
 		return nil, vm.ErrOutOfGas
 	}
-
-	if p.IsTransaction(method.Name) {
-		// Add journal entries for the precompile if it is a transaction
-		if err := p.AddJournalEntries(stateDB, snapshot); err != nil {
-			return nil, err
-		}
-	}
-
 	return bz, nil
 }
 

--- a/precompiles/common/precompile.go
+++ b/precompiles/common/precompile.go
@@ -58,26 +58,27 @@ func (p Precompile) RunSetup(
 	contract *vm.Contract,
 	readOnly bool,
 	isTransaction func(name string) bool,
-) (ctx sdk.Context, stateDB *statedb.StateDB, s snapshot, method *abi.Method, gasConfig sdk.Gas, args []interface{}, err error) {
+) (ctx sdk.Context, stateDB *statedb.StateDB, method *abi.Method, gasConfig sdk.Gas, args []interface{}, err error) {
 	stateDB, ok := evm.StateDB.(*statedb.StateDB)
 	if !ok {
-		return sdk.Context{}, nil, s, nil, uint64(0), nil, fmt.Errorf(ErrNotRunInEvm)
+		return sdk.Context{}, nil, nil, uint64(0), nil, fmt.Errorf(ErrNotRunInEvm)
 	}
 	// get the stateDB cache ctx
 	ctx, err = stateDB.GetCacheContext()
 	if err != nil {
-		return sdk.Context{}, nil, s, nil, uint64(0), nil, err
+		return sdk.Context{}, nil, nil, uint64(0), nil, err
 	}
 
 	// take a snapshot of the current state before any changes
 	// to be able to revert the changes
+	s := snapshot{}
 	s.MultiStore = stateDB.MultiStoreSnapshot()
 	s.Events = ctx.EventManager().Events()
 
 	// commit the current changes in the cache ctx
 	// to get the updated state for the precompile call
 	if err := stateDB.CommitWithCacheCtx(); err != nil {
-		return sdk.Context{}, nil, s, nil, uint64(0), nil, err
+		return sdk.Context{}, nil, nil, uint64(0), nil, err
 	}
 
 	// NOTE: This is a special case where the calling transaction does not specify a function name.
@@ -103,12 +104,12 @@ func (p Precompile) RunSetup(
 	}
 
 	if err != nil {
-		return sdk.Context{}, nil, s, nil, uint64(0), nil, err
+		return sdk.Context{}, nil, nil, uint64(0), nil, err
 	}
 
 	// return error if trying to write to state during a read-only call
 	if readOnly && isTransaction(method.Name) {
-		return sdk.Context{}, nil, s, nil, uint64(0), nil, vm.ErrWriteProtection
+		return sdk.Context{}, nil, nil, uint64(0), nil, vm.ErrWriteProtection
 	}
 
 	// if the method type is `function` continue looking for arguments
@@ -116,12 +117,14 @@ func (p Precompile) RunSetup(
 		argsBz := contract.Input[4:]
 		args, err = method.Inputs.Unpack(argsBz)
 		if err != nil {
-			return sdk.Context{}, nil, s, nil, uint64(0), nil, err
+			return sdk.Context{}, nil, nil, uint64(0), nil, err
 		}
 	}
 
 	initialGas := ctx.GasMeter().GasConsumed()
 
+	// explicitly assign nil to err to avoid superfluous panic
+	err = nil
 	defer HandleGasError(ctx, contract, initialGas, &err)()
 
 	// set the default SDK gas configuration to track gas usage
@@ -132,7 +135,24 @@ func (p Precompile) RunSetup(
 	// we need to consume the gas that was already used by the EVM
 	ctx.GasMeter().ConsumeGas(initialGas, "creating a new gas meter")
 
-	return ctx, stateDB, s, method, initialGas, args, nil
+	// add a snapshot of the current state before executing the precompile
+	// so that any out-of-gas errors during said execution are reverted correctly
+	if isTransaction(method.Name) {
+		if err := p.AddPrecompileSnapshot(stateDB, s); err != nil {
+			// if we have exceeded the limit of precompile calls, it will add the entry to the
+			// journal and return an error. then, we will revert that latest entry and hence
+			// the impact of this precompile call will be reverted.
+			// the added advantage of doing this here is that we do not waste resources
+			// to execute a precompile that will be reverted anyway.
+			return sdk.Context{}, nil, nil, uint64(0), nil, err
+		}
+	}
+
+	// return the error (set by HandleGasError) or nil
+	if err != nil {
+		return sdk.Context{}, nil, nil, uint64(0), nil, err
+	}
+	return ctx, stateDB, method, initialGas, args, nil
 }
 
 // HandleGasError handles the out of gas panic by resetting the gas meter and returning an error.
@@ -202,10 +222,12 @@ func (p Precompile) standardCallData(contract *vm.Contract) (method *abi.Method,
 	return method, nil
 }
 
-// AddJournalEntries adds the balanceChange (if corresponds)
-// and precompileCall entries on the stateDB journal
-// This allows to revert the call changes within an evm tx
-func (p Precompile) AddJournalEntries(stateDB *statedb.StateDB, s snapshot) error {
+// AddPrecompileSnapshot adds a snapshot of the current state to the journal.
+// It is called before executing a precompile to allow reverting the changes
+// caused by the precompile call.
+// NOTE: This does not include+ native balance changes and those must be added
+// separately AFTER the precompile call.
+func (p Precompile) AddPrecompileSnapshot(stateDB *statedb.StateDB, s snapshot) error {
 	if err := stateDB.AddPrecompileFn(p.Address(), s.MultiStore, s.Events); err != nil {
 		return err
 	}

--- a/precompiles/common/precompile.go
+++ b/precompiles/common/precompile.go
@@ -28,11 +28,6 @@ type Precompile struct {
 	Addr common.Address
 }
 
-type snapshot struct {
-	MultiStore storetypes.CacheMultiStore
-	Events     sdk.Events
-}
-
 // RequiredGas calculates the base minimum required gas for a transaction or a query.
 // It uses the method ID to determine if the input is a transaction or a query and
 // uses the Cosmos SDK gas config flat cost and the flat per byte cost * len(argBz) to calculate the gas.
@@ -71,9 +66,8 @@ func (p Precompile) RunSetup(
 
 	// take a snapshot of the current state before any changes
 	// to be able to revert the changes
-	s := snapshot{}
-	s.MultiStore = stateDB.MultiStoreSnapshot()
-	s.Events = ctx.EventManager().Events()
+	multiStore := stateDB.MultiStoreSnapshot()
+	events := ctx.EventManager().Events()
 
 	// commit the current changes in the cache ctx
 	// to get the updated state for the precompile call
@@ -136,16 +130,12 @@ func (p Precompile) RunSetup(
 	ctx.GasMeter().ConsumeGas(initialGas, "creating a new gas meter")
 
 	// add a snapshot of the current state before executing the precompile
-	// so that any out-of-gas errors during said execution are reverted correctly
+	// so that any errors during said execution are reverted correctly
 	if isTransaction(method.Name) {
-		if err := p.AddPrecompileSnapshot(stateDB, s); err != nil {
-			// if we have exceeded the limit of precompile calls, it will add the entry to the
-			// journal and return an error. then, we will revert that latest entry and hence
-			// the impact of this precompile call will be reverted.
-			// the added advantage of doing this here is that we do not waste resources
-			// to execute a precompile that will be reverted anyway.
+		if err := stateDB.AddPrecompileFn(p.Address(), multiStore, events); err != nil {
 			return sdk.Context{}, nil, nil, uint64(0), nil, err
 		}
+		// native balance changes should be added in Run.
 	}
 
 	// return the error (set by HandleGasError) or nil
@@ -220,18 +210,6 @@ func (p Precompile) standardCallData(contract *vm.Contract) (method *abi.Method,
 	}
 
 	return method, nil
-}
-
-// AddPrecompileSnapshot adds a snapshot of the current state to the journal.
-// It is called before executing a precompile to allow reverting the changes
-// caused by the precompile call.
-// NOTE: This does not include+ native balance changes and those must be added
-// separately AFTER the precompile call.
-func (p Precompile) AddPrecompileSnapshot(stateDB *statedb.StateDB, s snapshot) error {
-	if err := stateDB.AddPrecompileFn(p.Address(), s.MultiStore, s.Events); err != nil {
-		return err
-	}
-	return nil
 }
 
 func (p Precompile) Address() common.Address {

--- a/precompiles/common/precompile.go
+++ b/precompiles/common/precompile.go
@@ -56,12 +56,12 @@ func (p Precompile) RunSetup(
 ) (ctx sdk.Context, stateDB *statedb.StateDB, method *abi.Method, gasConfig sdk.Gas, args []interface{}, err error) {
 	stateDB, ok := evm.StateDB.(*statedb.StateDB)
 	if !ok {
-		return sdk.Context{}, nil, nil, uint64(0), nil, fmt.Errorf(ErrNotRunInEvm)
+		return sdk.Context{}, nil, nil, sdk.Gas(0), nil, fmt.Errorf(ErrNotRunInEvm)
 	}
 	// get the stateDB cache ctx
 	ctx, err = stateDB.GetCacheContext()
 	if err != nil {
-		return sdk.Context{}, nil, nil, uint64(0), nil, err
+		return sdk.Context{}, nil, nil, sdk.Gas(0), nil, err
 	}
 
 	// take a snapshot of the current state before any changes
@@ -72,7 +72,7 @@ func (p Precompile) RunSetup(
 	// commit the current changes in the cache ctx
 	// to get the updated state for the precompile call
 	if err := stateDB.CommitWithCacheCtx(); err != nil {
-		return sdk.Context{}, nil, nil, uint64(0), nil, err
+		return sdk.Context{}, nil, nil, sdk.Gas(0), nil, err
 	}
 
 	// NOTE: This is a special case where the calling transaction does not specify a function name.
@@ -98,12 +98,12 @@ func (p Precompile) RunSetup(
 	}
 
 	if err != nil {
-		return sdk.Context{}, nil, nil, uint64(0), nil, err
+		return sdk.Context{}, nil, nil, sdk.Gas(0), nil, err
 	}
 
 	// return error if trying to write to state during a read-only call
 	if readOnly && isTransaction(method.Name) {
-		return sdk.Context{}, nil, nil, uint64(0), nil, vm.ErrWriteProtection
+		return sdk.Context{}, nil, nil, sdk.Gas(0), nil, vm.ErrWriteProtection
 	}
 
 	// if the method type is `function` continue looking for arguments
@@ -111,14 +111,13 @@ func (p Precompile) RunSetup(
 		argsBz := contract.Input[4:]
 		args, err = method.Inputs.Unpack(argsBz)
 		if err != nil {
-			return sdk.Context{}, nil, nil, uint64(0), nil, err
+			return sdk.Context{}, nil, nil, sdk.Gas(0), nil, err
 		}
 	}
 
 	initialGas := ctx.GasMeter().GasConsumed()
 
-	// explicitly assign nil to err to avoid superfluous panic
-	err = nil
+	// if we are here, error is nil.
 	defer HandleGasError(ctx, contract, initialGas, &err)()
 
 	// set the default SDK gas configuration to track gas usage
@@ -133,16 +132,16 @@ func (p Precompile) RunSetup(
 	// so that any errors during said execution are reverted correctly
 	if isTransaction(method.Name) {
 		if err := stateDB.AddPrecompileFn(p.Address(), multiStore, events); err != nil {
-			return sdk.Context{}, nil, nil, uint64(0), nil, err
+			return sdk.Context{}, nil, nil, sdk.Gas(0), nil, err
 		}
 		// native balance changes should be added in Run.
 	}
 
 	// return the error (set by HandleGasError) or nil
 	if err != nil {
-		return sdk.Context{}, nil, nil, uint64(0), nil, err
+		return sdk.Context{}, nil, nil, sdk.Gas(0), nil, err
 	}
-	return ctx, stateDB, method, initialGas, args, nil
+	return ctx, stateDB, method, sdk.Gas(initialGas), args, nil
 }
 
 // HandleGasError handles the out of gas panic by resetting the gas meter and returning an error.

--- a/precompiles/distribution/distribution.go
+++ b/precompiles/distribution/distribution.go
@@ -89,7 +89,7 @@ func (p Precompile) RequiredGas(input []byte) uint64 {
 
 // Run executes the precompiled contract distribution methods defined in the ABI.
 func (p Precompile) Run(evm *vm.EVM, contract *vm.Contract, readOnly bool) (bz []byte, err error) {
-	ctx, stateDB, snapshot, method, initialGas, args, err := p.RunSetup(evm, contract, readOnly, p.IsTransaction)
+	ctx, stateDB, method, initialGas, args, err := p.RunSetup(evm, contract, readOnly, p.IsTransaction)
 	if err != nil {
 		return nil, err
 	}
@@ -136,13 +136,6 @@ func (p Precompile) Run(evm *vm.EVM, contract *vm.Contract, readOnly bool) (bz [
 
 	if !contract.UseGas(cost) {
 		return nil, vm.ErrOutOfGas
-	}
-
-	if p.IsTransaction(method.Name) {
-		// only add a journal entry if it's not a read-only call
-		if err := p.AddJournalEntries(stateDB, snapshot); err != nil {
-			return nil, err
-		}
 	}
 
 	return bz, nil

--- a/precompiles/erc20/erc20.go
+++ b/precompiles/erc20/erc20.go
@@ -128,7 +128,7 @@ func (p Precompile) RequiredGas(input []byte) uint64 {
 
 // Run executes the precompiled contract ERC-20 methods defined in the ABI.
 func (p Precompile) Run(evm *vm.EVM, contract *vm.Contract, readOnly bool) (bz []byte, err error) {
-	ctx, stateDB, snapshot, method, initialGas, args, err := p.RunSetup(evm, contract, readOnly, p.IsTransaction)
+	ctx, stateDB, method, initialGas, args, err := p.RunSetup(evm, contract, readOnly, p.IsTransaction)
 	if err != nil {
 		return nil, err
 	}
@@ -146,13 +146,6 @@ func (p Precompile) Run(evm *vm.EVM, contract *vm.Contract, readOnly bool) (bz [
 
 	if !contract.UseGas(cost) {
 		return nil, vm.ErrOutOfGas
-	}
-
-	if p.IsTransaction(method.Name) {
-		// only add a journal entry if it's not a read-only call
-		if err := p.AddJournalEntries(stateDB, snapshot); err != nil {
-			return nil, err
-		}
 	}
 
 	return bz, nil

--- a/precompiles/ics20/ics20.go
+++ b/precompiles/ics20/ics20.go
@@ -88,7 +88,7 @@ func (p Precompile) RequiredGas(input []byte) uint64 {
 
 // Run executes the precompiled contract IBC transfer methods defined in the ABI.
 func (p Precompile) Run(evm *vm.EVM, contract *vm.Contract, readOnly bool) (bz []byte, err error) {
-	ctx, stateDB, snapshot, method, initialGas, args, err := p.RunSetup(evm, contract, readOnly, p.IsTransaction)
+	ctx, stateDB, method, initialGas, args, err := p.RunSetup(evm, contract, readOnly, p.IsTransaction)
 	if err != nil {
 		return nil, err
 	}
@@ -132,13 +132,6 @@ func (p Precompile) Run(evm *vm.EVM, contract *vm.Contract, readOnly bool) (bz [
 
 	if !contract.UseGas(cost) {
 		return nil, vm.ErrOutOfGas
-	}
-
-	if p.IsTransaction(method.Name) {
-		// only add a journal entry if it's not a read-only call
-		if err := p.AddJournalEntries(stateDB, snapshot); err != nil {
-			return nil, err
-		}
 	}
 
 	return bz, nil

--- a/precompiles/outposts/osmosis/osmosis.go
+++ b/precompiles/outposts/osmosis/osmosis.go
@@ -131,7 +131,7 @@ func (Precompile) IsTransaction(method string) bool {
 
 // Run executes the precompiled contract Swap method.
 func (p Precompile) Run(evm *vm.EVM, contract *vm.Contract, readOnly bool) (bz []byte, err error) {
-	ctx, stateDB, snapshot, method, initialGas, args, err := p.RunSetup(evm, contract, readOnly, p.IsTransaction)
+	ctx, stateDB, method, initialGas, args, err := p.RunSetup(evm, contract, readOnly, p.IsTransaction)
 	if err != nil {
 		return nil, err
 	}
@@ -155,13 +155,6 @@ func (p Precompile) Run(evm *vm.EVM, contract *vm.Contract, readOnly bool) (bz [
 
 	if !contract.UseGas(cost) {
 		return nil, vm.ErrOutOfGas
-	}
-
-	if p.IsTransaction(method.Name) {
-		// only add a journal entry if it's not a read-only call
-		if err := p.AddJournalEntries(stateDB, snapshot); err != nil {
-			return nil, err
-		}
 	}
 
 	return bz, nil

--- a/precompiles/outposts/stride/stride.go
+++ b/precompiles/outposts/stride/stride.go
@@ -105,7 +105,7 @@ func (p Precompile) RequiredGas(input []byte) uint64 {
 
 // Run executes the precompiled contract IBC transfer methods defined in the ABI.
 func (p Precompile) Run(evm *vm.EVM, contract *vm.Contract, readOnly bool) (bz []byte, err error) {
-	ctx, stateDB, snapshot, method, initialGas, args, err := p.RunSetup(evm, contract, readOnly, p.IsTransaction)
+	ctx, stateDB, method, initialGas, args, err := p.RunSetup(evm, contract, readOnly, p.IsTransaction)
 	if err != nil {
 		return nil, err
 	}
@@ -132,13 +132,6 @@ func (p Precompile) Run(evm *vm.EVM, contract *vm.Contract, readOnly bool) (bz [
 
 	if !contract.UseGas(cost) {
 		return nil, vm.ErrOutOfGas
-	}
-
-	if p.IsTransaction(method.Name) {
-		// only add a journal entry if it's not a read-only call
-		if err := p.AddJournalEntries(stateDB, snapshot); err != nil {
-			return nil, err
-		}
 	}
 
 	return bz, nil

--- a/precompiles/staking/staking.go
+++ b/precompiles/staking/staking.go
@@ -85,7 +85,7 @@ func (p Precompile) RequiredGas(input []byte) uint64 {
 
 // Run executes the precompiled contract staking methods defined in the ABI.
 func (p Precompile) Run(evm *vm.EVM, contract *vm.Contract, readOnly bool) (bz []byte, err error) {
-	ctx, stateDB, snapshot, method, initialGas, args, err := p.RunSetup(evm, contract, readOnly, p.IsTransaction)
+	ctx, stateDB, method, initialGas, args, err := p.RunSetup(evm, contract, readOnly, p.IsTransaction)
 	if err != nil {
 		return nil, err
 	}
@@ -145,13 +145,6 @@ func (p Precompile) Run(evm *vm.EVM, contract *vm.Contract, readOnly bool) (bz [
 
 	if !contract.UseGas(cost) {
 		return nil, vm.ErrOutOfGas
-	}
-
-	if p.IsTransaction(method.Name) {
-		// only add a journal entry if it's not a read-only call
-		if err := p.AddJournalEntries(stateDB, snapshot); err != nil {
-			return nil, err
-		}
 	}
 
 	return bz, nil

--- a/precompiles/vesting/vesting.go
+++ b/precompiles/vesting/vesting.go
@@ -89,7 +89,7 @@ func NewPrecompile(
 
 // Run executes the precompiled contract vesting methods defined in the ABI.
 func (p Precompile) Run(evm *vm.EVM, contract *vm.Contract, readOnly bool) (bz []byte, err error) {
-	ctx, stateDB, snapshot, method, initialGas, args, err := p.RunSetup(evm, contract, readOnly, p.IsTransaction)
+	ctx, stateDB, method, initialGas, args, err := p.RunSetup(evm, contract, readOnly, p.IsTransaction)
 	if err != nil {
 		return nil, err
 	}
@@ -130,13 +130,6 @@ func (p Precompile) Run(evm *vm.EVM, contract *vm.Contract, readOnly bool) (bz [
 
 	if !contract.UseGas(cost) {
 		return nil, vm.ErrOutOfGas
-	}
-
-	if p.IsTransaction(method.Name) {
-		// only add a journal entry if it's not a read-only call
-		if err := p.AddJournalEntries(stateDB, snapshot); err != nil {
-			return nil, err
-		}
 	}
 
 	return bz, nil

--- a/precompiles/werc20/werc20.go
+++ b/precompiles/werc20/werc20.go
@@ -101,7 +101,7 @@ func (p Precompile) RequiredGas(input []byte) uint64 {
 
 // Run executes the precompiled contract WERC20 methods defined in the ABI.
 func (p Precompile) Run(evm *vm.EVM, contract *vm.Contract, readOnly bool) (bz []byte, err error) {
-	ctx, stateDB, snapshot, method, initialGas, args, err := p.Precompile.RunSetup(evm, contract, readOnly, p.IsTransaction)
+	ctx, stateDB, method, initialGas, args, err := p.Precompile.RunSetup(evm, contract, readOnly, p.IsTransaction)
 	if err != nil {
 		return nil, err
 	}
@@ -132,13 +132,6 @@ func (p Precompile) Run(evm *vm.EVM, contract *vm.Contract, readOnly bool) (bz [
 
 	if !contract.UseGas(cost) {
 		return nil, vm.ErrOutOfGas
-	}
-
-	if p.IsTransaction(method.Name) {
-		// only add a journal entry if it's not a read-only call
-		if err := p.AddJournalEntries(stateDB, snapshot); err != nil {
-			return nil, err
-		}
 	}
 
 	return bz, nil

--- a/x/evm/keeper/statedb.go
+++ b/x/evm/keeper/statedb.go
@@ -158,12 +158,6 @@ func (k *Keeper) SetState(ctx sdk.Context, addr common.Address, key common.Hash,
 	)
 }
 
-// DeleteState deletes the entry for the given key in the contract storage
-// at the defined contract address.
-func (k *Keeper) DeleteState(ctx sdk.Context, addr common.Address, key common.Hash) {
-	k.SetState(ctx, addr, key, nil)
-}
-
 // SetCode set contract code, delete if code is empty.
 func (k *Keeper) SetCode(ctx sdk.Context, codeHash, code []byte) {
 	store := prefix.NewStore(ctx.KVStore(k.storeKey), types.KeyPrefixCode)
@@ -180,12 +174,6 @@ func (k *Keeper) SetCode(ctx sdk.Context, codeHash, code []byte) {
 		fmt.Sprintf("code %s", action),
 		"code-hash", common.BytesToHash(codeHash).Hex(),
 	)
-}
-
-// DeleteCode deletes the contract code for the given code hash bytes in
-// the corresponding store.
-func (k *Keeper) DeleteCode(ctx sdk.Context, codeHash []byte) {
-	k.SetCode(ctx, codeHash, nil)
 }
 
 // DeleteAccount handles contract's suicide call:

--- a/x/evm/statedb/interfaces.go
+++ b/x/evm/statedb/interfaces.go
@@ -30,8 +30,6 @@ type Keeper interface {
 	// Write methods, only called by `StateDB.Commit()`
 	SetAccount(ctx sdk.Context, addr common.Address, account Account) error
 	SetState(ctx sdk.Context, addr common.Address, key common.Hash, value []byte)
-	DeleteState(ctx sdk.Context, addr common.Address, key common.Hash)
 	SetCode(ctx sdk.Context, codeHash []byte, code []byte)
-	DeleteCode(ctx sdk.Context, codeHash []byte)
 	DeleteAccount(ctx sdk.Context, addr common.Address) error
 }

--- a/x/evm/statedb/statedb.go
+++ b/x/evm/statedb/statedb.go
@@ -515,12 +515,8 @@ func (s *StateDB) commitWithCtx(ctx sdk.Context) error {
 				return errorsmod.Wrapf(err, "failed to delete account %s", obj.Address())
 			}
 		} else {
-			if obj.code != nil && obj.dirtyCode {
-				if len(obj.code) == 0 {
-					s.keeper.DeleteCode(ctx, obj.CodeHash())
-				} else {
-					s.keeper.SetCode(ctx, obj.CodeHash(), obj.code)
-				}
+			if obj.dirtyCode {
+				s.keeper.SetCode(ctx, obj.CodeHash(), obj.code)
 			}
 			if err := s.keeper.SetAccount(ctx, obj.Address(), obj.account); err != nil {
 				return errorsmod.Wrap(err, "failed to set account")
@@ -533,12 +529,7 @@ func (s *StateDB) commitWithCtx(ctx sdk.Context) error {
 				if (ok && transientValue == dirtyValue) || (!ok && dirtyValue == originValue) {
 					continue
 				}
-				valueBytes := dirtyValue.Bytes()
-				if len(valueBytes) == 0 {
-					s.keeper.DeleteState(ctx, obj.Address(), key)
-				} else {
-					s.keeper.SetState(ctx, obj.Address(), key, valueBytes)
-				}
+				s.keeper.SetState(ctx, obj.Address(), key, dirtyValue.Bytes())
 				obj.transientStorage[key] = dirtyValue
 			}
 		}

--- a/x/evm/statedb/statedb.go
+++ b/x/evm/statedb/statedb.go
@@ -485,8 +485,6 @@ func (s *StateDB) RevertToSnapshot(revid int) {
 	// Replay the journal to undo changes and remove invalidated snapshots
 	s.journal.Revert(s, snapshot)
 	s.validRevisions = s.validRevisions[:idx]
-	// If there is a revert, the write cache is invalidated.
-	s.cache()
 }
 
 // Commit writes the dirty states to keeper


### PR DESCRIPTION
If a precompile error (out-of-gas or otherwise) is triggered (and cascaded upwards instead of being wrapped) during the precompile's execution, journal entries associated with the precompile are missing from stateDB. This change fixes that issue by ensuring that precompile level journal entries are created **_before_** execution of the precompile begins.

Note that it does NOT handle native balance changes, which should ideally be synchronized with stateDB after the precompile is executed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Refactor**
  - Simplified internal logic for handling state and journal entries in precompile modules by removing snapshot usage.
  - Unified and streamlined the process for updating and committing contract code and storage, removing conditional deletion logic.
- **Chores**
  - Removed unused snapshot structures and related methods from precompile modules.
  - Eliminated explicit delete functions for contract state and code from the system, consolidating state management.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->